### PR TITLE
Various small fixes to resources pages. Small tweaks to code of conduct

### DIFF
--- a/about/code-of-conduct.md
+++ b/about/code-of-conduct.md
@@ -26,9 +26,9 @@ OceanHackWeek organizers may take action to redress anything designed to, or wit
 
 
 ## Reporting a violation
-Harassment and other code of conduct violations reduce the value of OceanHackWeek for everyone. If someone makes you or anyone else feel unsafe or unwelcome, please report it as soon as possible to one of the instructors. You can make a report either personally or anonymously. **Anonymous reports can be made [here](https://oceanhackweek.wufoo.com/forms/zep2ybt1swlulc/).**
+Harassment and other code of conduct violations reduce the value of OceanHackWeek for everyone. If someone makes you or anyone else feel unsafe or unwelcome, please report it as soon as possible to one of the organizers or instructors. You can make a report either personally or anonymously. **Anonymous reports can be made [here](https://oceanhackweek.wufoo.com/forms/zep2ybt1swlulc/).**
 
-This anti-harassment policy is based on the example policy from the Geek Feminism wiki, created by the Ada Initiative and other volunteers.
+This anti-harassment policy is based on the example policy from the [Geek Feminism wiki](https://geekfeminism.fandom.com), created by the [Ada Initiative](https://adainitiative.org/) and other volunteers.
 
 
 ## Group discussion

--- a/index.md
+++ b/index.md
@@ -146,6 +146,6 @@ Virtual event: We expect to hold formal sessions in at least two time zones, USA
 about/index.md
 % about/pasthackweeks.md
 OceanHackWeek 2022 <ohw22/index.md>
-OHW22 Resources <resources/index.md>
+resources/index.md
 % posts
 ```

--- a/index.md
+++ b/index.md
@@ -146,6 +146,6 @@ Virtual event: We expect to hold formal sessions in at least two time zones, USA
 about/index.md
 % about/pasthackweeks.md
 OceanHackWeek 2022 <ohw22/index.md>
-resources/index.md
+OHW22 Resources <resources/index.md>
 % posts
 ```

--- a/ohw22/index.md
+++ b/ohw22/index.md
@@ -94,8 +94,9 @@ In coordination with the OHW Northwest satellite event, there will be a **[3-wee
 :caption: OceanHackWeek 2022 (OHW22)
 :hidden:
 
-Information for Applicants <applicants>
+Resources </resources>
 Global Virtual Event <global/index>
 Regional Satellite Events <satellites>
+Information for Applicants <applicants>
 Organizers <organizers>
 ```

--- a/ohw22/index.md
+++ b/ohw22/index.md
@@ -94,9 +94,9 @@ In coordination with the OHW Northwest satellite event, there will be a **[3-wee
 :caption: OceanHackWeek 2022 (OHW22)
 :hidden:
 
-Resources </resources>
 Global Virtual Event <global/index>
 Regional Satellite Events <satellites>
+Resources </resources/index>
 Information for Applicants <applicants>
 Organizers <organizers>
 ```

--- a/resources/index.md
+++ b/resources/index.md
@@ -1,4 +1,4 @@
-# Resources
+# OHW22 Resources
 
 :::{admonition} Updates in progress
 :class: warning

--- a/resources/index.md
+++ b/resources/index.md
@@ -21,6 +21,12 @@ We will use a [JupyterHub](https://jupyter.org/hub)-based online environment for
 
 We will use Slack, Zoom and GitHub as our primary communication and content delivery platforms. The week before OceanHackWeek you will receive via email an invitation to join the OceanHackWeek GitHub organization, [https://github.com/oceanhackweek/](https://github.com/oceanhackweek/) if you have not received it already, along with Slack invites and Zoom connection info.
 
+
+```{toctree}
+:hidden:
+Code of Conduct </about/code-of-conduct>
+```
+
 ```{toctree}
 :maxdepth: 2
 :hidden:

--- a/resources/index.md
+++ b/resources/index.md
@@ -7,7 +7,7 @@ The resources are actively being updated! Some parts are still out of date, and 
 
 :::
 
-To make sure that OHW21 will be a welcoming environment for everyone, please read our [Code of Conduct](/about/code-of-conduct.md) carefully as part of your preparation. We expect all participants to adhere to the Code of Conduct in all interactions throughout the hackweek.
+To make sure that OHW22 will be a welcoming environment for everyone, please read our [Code of Conduct](/about/code-of-conduct.md) carefully as part of your preparation. We expect all participants to adhere to the Code of Conduct in all interactions throughout the hackweek.
 
 ## Schedules
 
@@ -34,13 +34,12 @@ schedule
 
 ```{toctree}
 :hidden:
-:caption: Preperation
+:caption: Preparation
 
-prep/git
+Git <prep/git>
 prep/github
 prep/jupyterhub
-prep/conda
-
+Conda, Python, R <prep/conda>
 ```
 
 ```{toctree}
@@ -48,7 +47,6 @@ prep/conda
 :caption: Tutorials
 
 tutorials/getting_started
-
 ```
 
 ```{toctree}
@@ -57,7 +55,6 @@ tutorials/getting_started
 
 projects/overview
 projects/steps
-
 ```
 
 ```{toctree}

--- a/resources/logistics/getting_help.md
+++ b/resources/logistics/getting_help.md
@@ -42,5 +42,5 @@ See the [Projects Getting Started page](../projects/steps.md). Feel free to post
 
 ## Reporting a Code of Conduct violation
 
-Harassment and other [Code of Conduct violations](../conduct.md) reduce the value of OceanHackWeek for everyone. If someone makes you or anyone else feel unsafe or unwelcome, please report it as soon as possible to one of the instructors. You can make a report either personally or anonymously. **Anonymous reports can be made [here](https://oceanhackweek.wufoo.com/forms/zep2ybt1swlulc/).**
+Harassment and other [Code of Conduct violations](/about/code-of-conduct.md) reduce the value of OceanHackWeek for everyone. If someone makes you or anyone else feel unsafe or unwelcome, please report it as soon as possible to one of the organizers or instructors. You can make a report either personally or anonymously. **Anonymous reports can be made [here](https://oceanhackweek.wufoo.com/forms/zep2ybt1swlulc/).**
 

--- a/resources/prep/git.md
+++ b/resources/prep/git.md
@@ -214,7 +214,7 @@ Submit a pull request by clicking `New pull request`:
 * Reviewer: look through changes in the files
 * Approve PR or ask for more changes.
 
-```{admonition}
+```{admonition} Note
 While your pull request is pending, any change you push to the fork will become a part of the request. This is useful if you are asked to make small changes before your PR is accepted.
 ```
 

--- a/resources/prep/github.md
+++ b/resources/prep/github.md
@@ -9,9 +9,9 @@ The resources are actively being updated! Some parts are still out of date, and 
 
 ## About Git and GitHub
 
-[Git](https://git-scm.com/) is a popular version control system that is the foundation of most open source software development. You are not required to be a Git pro in advance of this event, but come prepared to learn a lot about it! [GitHub](github.com) is a hosting service for Git repositories, enabling us to share code across teams in a web environment.
+[Git](https://git-scm.com/) is a popular version control system that is the foundation of most open source software development. You are not required to be a Git pro in advance of this event, but come prepared to learn a lot about it! [GitHub](https://github.com) is a hosting service for Git repositories, enabling us to share code across teams in a web environment.
 
-We will use Git and GitHub for collaborative work. Be sure to arrive at {OceanHackWeek with your own [GitHub](https://github.com/) account.
+We will use Git and GitHub for collaborative work. Be sure to arrive at {OceanHackWeek with your own [GitHub](https://github.com) account.
 
 ## Why do I need a GitHub account?
 
@@ -30,7 +30,7 @@ Then, click on the big green button and then answer a few required questions. Be
 
 GitHub organizations are a convenient way for teams to get all content relevant to a specific project or workshop into one place. By having everything in one central location you will spend less time searching for hackweek content. GitHub organizations have "teams" that offer simple ways to provide respository access to groups of people, rather than individuals.
 
-We have created a GitHub organization called oceanhackweek at [https://github.com/oceanhackweek](https://github.com/oceanhackweek). For security purposes you can only join the organization by invitation. You should already have received the invitation to GitHub. If you didn't:
+We have created a GitHub organization called "oceanhackweek" at [https://github.com/oceanhackweek](https://github.com/oceanhackweek). For security purposes you can only join the organization by invitation. You should already have received the invitation to GitHub. If you didn't:
 
 1. Once you have a GitHub ID, in the `#ohw22-helpdesk` Slack channel ask for help and include `@help-infrastructure` in your message so that folks who have the ability to make changes are notified.
 2. We will then send you an invitation which should generate an email notification to the email you provided when you signed up for GitHub

--- a/resources/prep/jupyterhub.md
+++ b/resources/prep/jupyterhub.md
@@ -1,4 +1,4 @@
-# JupyterHub
+# Jupyter and the Hub
 
 :::{admonition} Updates in progress
 :class: warning


### PR DESCRIPTION
This is a small set of changes. I'm still going over the Resources pages and thinking through some potentially larger changes.

- In resources pages, fixed some warnings and errors involving broken links, an admonition, etc
- Changed the "Resources" menu item to "OHW22 Resources", to make it more overly obvious
- Code of Conduct
  - Tweaked code of conduct text (having nothing to do specifically with Resources pages, though it does involve one Resources page)
    - Changed the wording "report it as soon as possible to one of the instructors" to "report it as soon as possible to one of the **organizers or** instructors"
    - Added links to two organizations mentioned in the Code of Conduct
  - Added a top-level Code of Conduct menu item in the Resources pages (*ok, that's not in this PR at this instant, but I'll push a commit shortly*)